### PR TITLE
se añadio el componente list-context.bullet-group

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -62,7 +62,8 @@
     "vtex.toggle-layout": "0.x",
     "vtex.store-link": "0.x",
     "vtex.product-specifications": "1.x",
-    "itgloberspartnercl.whatsapp-button": "0.x"
+    "itgloberspartnercl.whatsapp-button": "0.x",
+    "itgloberspartnercl.bullets-diagramation": "0.x"
   },
   "peerDependencies": {
     "vtex.mega-menu": "2.x",

--- a/store/blocks/global/components/bullet-group/list-context-bullet-group.jsonc
+++ b/store/blocks/global/components/bullet-group/list-context-bullet-group.jsonc
@@ -1,0 +1,14 @@
+{
+    "list-context.bullet-group":{
+        "title":"bullet group",
+        "props":{
+          "bullets":{
+            "image":"miimagen.png",
+            "titleBullet":"mi computador",
+            "link":{
+              "url":"/"
+            }
+          }
+        }
+      }
+}

--- a/store/blocks/global/screen/home.jsonc
+++ b/store/blocks/global/screen/home.jsonc
@@ -33,11 +33,13 @@
       "flex-layout.row#home__banner-falabella",
       "flex-layout.row#home__banner-app",
       "flex-layout.row#home__section_informacion-linio",
-      "whatsapp-button"
+      "whatsapp-button",
+      "list-context.bullet-group"
         ],
     "props": {
       "blockClass":"home__global"
     }
   }
+  
   
 }


### PR DESCRIPTION
Se añadio el componente custom "list-context.bullet-group" donde se pudo visualizar contenido dependiendo del tamaño de la pantalla , se agrego como dependencia en el manifest.json , son las primeras configuraciones asi que hay muy poco por ver
![image](https://user-images.githubusercontent.com/107804493/216712975-ead7dc92-32b2-4005-893b-1b28b7accfb7.png)
![image](https://user-images.githubusercontent.com/107804493/216713040-6441fd7c-a2f7-401b-a17e-c9c3169173e7.png)
