### PR TITLE
feat:pdf-reader added and stylized

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -65,7 +65,8 @@
     "itgloberspartnercl.whatsapp-button": "0.x",
     "itgloberspartnercl.bullets-diagramation": "0.x",
     "itgloberspartnercl.add-to-cart-info": "0.x",
-    "itgloberspartnercl.custom-department-search": "0.x"
+    "itgloberspartnercl.custom-department-search": "0.x",
+    "itgloberspartnercl.pdf-reader": "0.x"
   },
   "peerDependencies": {
     "vtex.mega-menu": "2.x",

--- a/store/blocks/pages/page__custom-components.jsonc
+++ b/store/blocks/pages/page__custom-components.jsonc
@@ -14,7 +14,8 @@
     },
     "flex-layout.col#custom__components--container":{
         "title":"container col custom components",
-        "children":["flex-layout.row#departmen-search"]
+        "children":["flex-layout.row#departmen-search",
+    "pdf-reader"]
     },
 
     "flex-layout.row#departmen-search":{
@@ -26,5 +27,13 @@
     },
     "department-search": {
         "title": "search departament"
+    },
+    "pdf-reader":{
+        "title":"pdf reader",
+        "props":{
+            "pdfUrl":"assets/documents/codigo__limpio.pdf",
+            "width":500,
+            "height":700
+        }
     }
 }


### PR DESCRIPTION
Se añadio al store-theme-linio el componente pdf-reader que permite visualizar los pdfs dentro de cualquier pagina creada en vtex.
![image](https://user-images.githubusercontent.com/107804493/217648227-d306819f-d123-486b-acdd-cf2de71d0d1e.png)